### PR TITLE
062426 grey out coming soon link cards

### DIFF
--- a/src/components/blocks/LinkGrid.astro
+++ b/src/components/blocks/LinkGrid.astro
@@ -39,19 +39,33 @@ function resolveHref(link: Link): string {
   {links.map((link) => {
     const href = resolveHref(link);
     const isExternal = link.external || href.startsWith('http');
-    return (
-      <a
-        href={href}
-        class:list={['link-grid-button', { 'under-construction': link.underConstruction }]}
-        target={isExternal ? '_blank' : undefined}
-        rel={isExternal ? 'noopener noreferrer' : undefined}
-      >
+    const cardClass = ['link-grid-button', { 'under-construction': link.underConstruction }];
+    const cardBody = (
+      <>
         <span class="link-grid-accent" aria-hidden="true"></span>
         <span class="link-grid-body">
           <span class="link-grid-label">{link.label}</span>
           {link.description && <span class="link-grid-description">{link.description}</span>}
         </span>
-        {link.underConstruction && <span class="under-construction-badge">Coming soon</span>}
+      </>
+    );
+
+    if (link.underConstruction) {
+      return (
+        <span class:list={cardClass} aria-disabled="true">
+          {cardBody}
+        </span>
+      );
+    }
+
+    return (
+      <a
+        href={href}
+        class:list={cardClass}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+      >
+        {cardBody}
       </a>
     );
   })}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -711,33 +711,24 @@ body {
     line-height: 1.4;
   }
   
-  /* Under construction badge */
+  /* Under construction — greyed out, not clickable */
   .link-grid-button.under-construction {
-    position: relative;
     background-color: var(--color-background-secondary);
     border-style: dashed;
     border-color: var(--color-foreground-border);
+    color: var(--color-foreground-muted);
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: 0.65;
   }
-  
-  .under-construction-badge {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    background-color: var(--color-accent);
-    color: #ffffff;
-    font-family: var(--font-stack);
-    font-size: var(--font-size--small--2);
-    font-weight: 600;
-    padding: 0.2rem 0.5rem;
-    border-radius: var(--radius-sm);
-    text-transform: none;
-    letter-spacing: 0.02em;
-    line-height: 1.2;
+
+  .link-grid-button.under-construction .link-grid-label,
+  .link-grid-button.under-construction .link-grid-description {
+    color: var(--color-foreground-muted);
   }
-  
-  .link-grid-button.under-construction:hover {
-    background-color: var(--color-background-hover);
-    border-color: var(--color-foreground-border);
+
+  .link-grid-button.under-construction .link-grid-accent {
+    background: var(--color-foreground-border);
   }
   
   


### PR DESCRIPTION
Removed the overlapping Coming soon badge on narrow viewports. Under-construction LinkGrid cards now render as disabled spans with muted styling instead of clickable links.